### PR TITLE
Changed the value setting method for step.input and step.additional_input during step execution

### DIFF
--- a/sdk/python/agent_protocol/agent.py
+++ b/sdk/python/agent_protocol/agent.py
@@ -99,8 +99,8 @@ async def execute_agent_task_step(
 
     step.status = Status.running
 
-    step.input = body.input if body else None
-    step.additional_input = body.additional_input if body else None
+    step.input = body.input if body else step.input
+    step.additional_input = body.additional_input if body else step.additional_input
 
     step = await _step_handler(step)
 


### PR DESCRIPTION
With the current specification, even if the agent generates prompts for executing steps during the planning phase, as shown in the code below, `None` will be set if the client does not explicitly provide the step's body.

```python
async def _plan(task: Task, step: Step) -> Step:
    planner = load_chat_planner(model)
    plans = planner.plan({"input": task.input}).steps
    for i, plan in enumerate(plans):
        is_last_step = i == len(plans) - 1
        await Agent.db.create_step(
            task_id=task.task_id,
            name=StepTypes.ACTION,
            input=plan.value,
            is_last=is_last_step
        )
    step.output = "\n".join([f"- {plan.value}" for s in plans])
    return step
```

I found it unnatural to always have to explicitly specify the prompt to be executed in the step from the client when calling the agent, so I created this pull request. If this change does not conflict with the design philosophy, please merge it.