### PR TITLE
Update OpenAPI Schema and Testing Suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,5 @@ cython_debug/
 
 .idea/
 
+# Testing Suite HTML Reports
+report.html

--- a/docs/src/app/endpoints/page.mdx
+++ b/docs/src/app/endpoints/page.mdx
@@ -44,7 +44,7 @@ curl --request POST http://localhost:8000/agent/tasks
 
 ---
 
-## List Agent Tasks I Ds {{ tag: 'GET', label: '/agent/tasks' }}
+## List Agent Tasks {{ tag: 'GET', label: '/agent/tasks' }}
 <Row>
   <Col>
     List all tasks that have been created for the agent.

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -151,7 +151,7 @@
         ]
       },
       "get": {
-        "operationId": "listAgentTasksIDs",
+        "operationId": "listAgentTasks",
         "summary": "List all tasks that have been created for the agent.",
         "parameters": [
           {

--- a/schemas/openapi.yml
+++ b/schemas/openapi.yml
@@ -34,7 +34,7 @@ paths:
       tags:
         - agent
     get:
-      operationId: listAgentTasksIDs
+      operationId: listAgentTasks
       summary: List all tasks that have been created for the agent.
       parameters:
         - name: current_page

--- a/testing_suite/contract_tests_env.json
+++ b/testing_suite/contract_tests_env.json
@@ -80,7 +80,7 @@
 		},
 		{
 			"key": "env-openapi-json-url",
-			"value": "https://raw.githubusercontent.com/merwanehamadi/agent-protocol/main/openapi.json",
+			"value": "https://raw.githubusercontent.com/AI-Engineers-Foundation/agent-protocol/main/schemas/openapi.json",
 			"type": "default",
 			"enabled": true
 		},

--- a/testing_suite/test.sh
+++ b/testing_suite/test.sh
@@ -49,21 +49,6 @@ Running the tests, this might take a while. Please wait...
 
 EOF
 
-newman run https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/testing_suite/agent_protocol_v0.4.json \
---env-var "url=$URL" \
--r htmlextra \
---reporter-htmlextra-export report.html \
---reporter-htmlextra-title "Agent Protocol Tests"
-
-agent_protocol_tests_results=$?
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  open report.html
-elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  xdg-open report.html
-fi
-echo "If the report wasn't generated, please open the report.html file in your browser."
-
 newman run https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/testing_suite/contract_tests.json \
 -e https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/testing_suite/contract_tests_env.json \
 --env-var "env-openapi-json-url=https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/schemas/openapi.json" \


### PR DESCRIPTION
Renamed `operationId` for `listAgentTasks` from `listAgentTasksIDs` to `listAgentTasks`

Removed newman command from the test script that doesn't test against the OpenAPI spec.

Added `report.html` to the .gitignore in case any reports are generated within the `testing_suite` folder, or anywhere else.