### PR TITLE
Spec v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
+# bun
+bun.lockb
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Right now the protocol is defined as a REST API (via the
 [OpenAPI spec](./schemas/openapi.yml)) with two essential routes for interaction with
 your agent:
 
-- `POST /agent/tasks` for creating a new task for the agent (for example giving
+- `POST /ap/v1/agent/tasks` for creating a new task for the agent (for example giving
   the agent an objective that you want to accomplish)
-- `POST /agent/tasks/{task_id}/steps` for executing one step of the defined task
+- `POST /ap/v1/agent/tasks/{task_id}/steps` for executing one step of the defined task
 
 It has also a few additional routes for listing the tasks, steps and downloading / uploading artifacts.
 

--- a/client/python/agent_protocol_client/api/agent_api.py
+++ b/client/python/agent_protocol_client/api/agent_api.py
@@ -203,7 +203,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks",
+            "/ap/v1/agent/tasks",
             "POST",
             _path_params,
             _query_params,
@@ -383,7 +383,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks/{task_id}/artifacts/{artifact_id}",
+            "/ap/v1/agent/tasks/{task_id}/artifacts/{artifact_id}",
             "GET",
             _path_params,
             _query_params,
@@ -571,7 +571,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks/{task_id}/steps",
+            "/ap/v1/agent/tasks/{task_id}/steps",
             "POST",
             _path_params,
             _query_params,
@@ -738,7 +738,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks/{task_id}",
+            "/ap/v1/agent/tasks/{task_id}",
             "GET",
             _path_params,
             _query_params,
@@ -918,7 +918,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks/{task_id}/steps/{step_id}",
+            "/ap/v1/agent/tasks/{task_id}/steps/{step_id}",
             "GET",
             _path_params,
             _query_params,
@@ -1087,7 +1087,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks/{task_id}/artifacts",
+            "/ap/v1/agent/tasks/{task_id}/artifacts",
             "GET",
             _path_params,
             _query_params,
@@ -1256,7 +1256,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks/{task_id}/steps",
+            "/ap/v1/agent/tasks/{task_id}/steps",
             "GET",
             _path_params,
             _query_params,
@@ -1405,7 +1405,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks",
+            "/ap/v1/agent/tasks",
             "GET",
             _path_params,
             _query_params,
@@ -1632,7 +1632,7 @@ class AgentApi(object):
         }
 
         return self.api_client.call_api(
-            "/agent/tasks/{task_id}/artifacts",
+            "/ap/v1/agent/tasks/{task_id}/artifacts",
             "POST",
             _path_params,
             _query_params,

--- a/client/python/agent_protocol_client/docs/AgentApi.md
+++ b/client/python/agent_protocol_client/docs/AgentApi.md
@@ -4,15 +4,15 @@ All URIs are relative to _http://localhost_
 
 | Method                                                                       | HTTP request                                           | Description                                                   |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------- |
-| [**create_agent_task**](AgentApi.md#create_agent_task)                       | **POST** /agent/tasks                                  | Creates a task for the agent.                                 |
-| [**download_agent_task_artifact**](AgentApi.md#download_agent_task_artifact) | **GET** /agent/tasks/{task_id}/artifacts/{artifact_id} | Download a specified artifact.                                |
-| [**execute_agent_task_step**](AgentApi.md#execute_agent_task_step)           | **POST** /agent/tasks/{task_id}/steps                  | Execute a step in the specified agent task.                   |
-| [**get_agent_task**](AgentApi.md#get_agent_task)                             | **GET** /agent/tasks/{task_id}                         | Get details about a specified agent task.                     |
-| [**get_agent_task_step**](AgentApi.md#get_agent_task_step)                   | **GET** /agent/tasks/{task_id}/steps/{step_id}         | Get details about a specified task step.                      |
-| [**list_agent_task_artifacts**](AgentApi.md#list_agent_task_artifacts)       | **GET** /agent/tasks/{task_id}/artifacts               | List all artifacts that have been created for the given task. |
-| [**list_agent_task_steps**](AgentApi.md#list_agent_task_steps)               | **GET** /agent/tasks/{task_id}/steps                   | List all steps for the specified task.                        |
-| [**list_agent_tasks_ids**](AgentApi.md#list_agent_tasks_ids)                 | **GET** /agent/tasks                                   | List all tasks that have been created for the agent.          |
-| [**upload_agent_task_artifacts**](AgentApi.md#upload_agent_task_artifacts)   | **POST** /agent/tasks/{task_id}/artifacts              | Upload an artifact for the specified task.                    |
+| [**create_agent_task**](AgentApi.md#create_agent_task)                       | **POST** /ap/v1/agent/tasks                                  | Creates a task for the agent.                                 |
+| [**download_agent_task_artifact**](AgentApi.md#download_agent_task_artifact) | **GET** /ap/v1/agent/tasks/{task_id}/artifacts/{artifact_id} | Download a specified artifact.                                |
+| [**execute_agent_task_step**](AgentApi.md#execute_agent_task_step)           | **POST** /ap/v1/agent/tasks/{task_id}/steps                  | Execute a step in the specified agent task.                   |
+| [**get_agent_task**](AgentApi.md#get_agent_task)                             | **GET** /ap/v1/agent/tasks/{task_id}                         | Get details about a specified agent task.                     |
+| [**get_agent_task_step**](AgentApi.md#get_agent_task_step)                   | **GET** /ap/v1/agent/tasks/{task_id}/steps/{step_id}         | Get details about a specified task step.                      |
+| [**list_agent_task_artifacts**](AgentApi.md#list_agent_task_artifacts)       | **GET** /ap/v1/agent/tasks/{task_id}/artifacts               | List all artifacts that have been created for the given task. |
+| [**list_agent_task_steps**](AgentApi.md#list_agent_task_steps)               | **GET** /ap/v1/agent/tasks/{task_id}/steps                   | List all steps for the specified task.                        |
+| [**list_agent_tasks_ids**](AgentApi.md#list_agent_tasks_ids)                 | **GET** /ap/v1/agent/tasks                                   | List all tasks that have been created for the agent.          |
+| [**upload_agent_task_artifacts**](AgentApi.md#upload_agent_task_artifacts)   | **POST** /ap/v1/agent/tasks/{task_id}/artifacts              | Upload an artifact for the specified task.                    |
 
 # **create_agent_task**
 

--- a/docs/src/app/clients/others/page.mdx
+++ b/docs/src/app/clients/others/page.mdx
@@ -19,7 +19,7 @@ const url = 'http://localhost:8000'
 const body = JSON.stringify({ input: 'task-input-to-your-agent' })
 
 // Create task
-let response = await fetch(`${url}/agent/tasks`, { method: 'POST' }, { body })
+let response = await fetch(`${url}/ap/v1/agent/tasks`, { method: 'POST' }, { body })
 let data = await response.json()
 
 const taskId = data.task_id
@@ -27,7 +27,7 @@ let isLast = false
 
 // Execute steps until the completion
 while (!isLast) {
-  response = await fetch(`${url}/agent/tasks/${taskId}/steps`, {
+  response = await fetch(`${url}/ap/v1/agent/tasks/${taskId}/steps`, {
     method: 'POST',
   })
   data = await response.json()
@@ -46,7 +46,7 @@ To **create a task** run
 
 ```sh
 curl --request POST \
-  --url http://localhost:8000/agent/tasks \
+  --url http://localhost:8000/ap/v1/agent/tasks \
   --header 'Content-Type: application/json' \
   --data '{
 	"input": "task-input-to-your-agent"
@@ -68,7 +68,7 @@ previous request and run:
 
 ```sh
 curl --request POST \
-  --url http://localhost:8000/agent/tasks/<task-id>/steps
+  --url http://localhost:8000/ap/v1/agent/tasks/<task-id>/steps
 ```
 
 To get response like this:

--- a/docs/src/app/endpoints/page.mdx
+++ b/docs/src/app/endpoints/page.mdx
@@ -8,7 +8,32 @@ export const metadata = {
 
 The agent exposes the following endpoints (see the [OpenAPI file](https://github.com/e2b-dev/agent-protocol/blob/main/schemas/openapi.yml)):
 
-## Create Agent Task {{ tag: 'POST', label: '/agent/tasks' }}
+## Get Agent Info {{ tag: 'GET', label: '/ap/v1/agent/info' }}
+<Row>
+  <Col>
+    Get information about the agent.
+
+    
+    
+   
+    ### Response
+  
+    Returned information about the agent.
+
+  </Col>
+  <Col sticky>
+    <CodeGroup title="Request" tag="GET" label="/ap/v1/agent/info">
+```bash {{ title: 'cURL' }}
+curl  http://localhost:8000/ap/v1/agent/info
+
+```
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Create Agent Task {{ tag: 'POST', label: '/ap/v1/agent/tasks' }}
 <Row>
   <Col>
     Creates a task for the agent.
@@ -21,8 +46,8 @@ The agent exposes the following endpoints (see the [OpenAPI file](https://github
     <Property name="input" type="string" required="undefined">
         Input prompt for the task.
     </Property>
-    <Property name="additional_input" type="object" required="undefined">
-        Input parameters for the task. Any value is allowed.
+    <Property name="config" type="object" required="undefined">
+        Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.
     </Property>
   </Properties>
    
@@ -32,11 +57,11 @@ The agent exposes the following endpoints (see the [OpenAPI file](https://github
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/agent/tasks">
+    <CodeGroup title="Request" tag="POST" label="/ap/v1/agent/tasks">
 ```bash {{ title: 'cURL' }}
-curl --request POST http://localhost:8000/agent/tasks
+curl --request POST http://localhost:8000/ap/v1/agent/tasks
     -F 'input=[input]'
-    -F 'additional_input=[additional_input]'
+    -F 'config=[config]'
 ```
     </CodeGroup>
   </Col>
@@ -44,7 +69,7 @@ curl --request POST http://localhost:8000/agent/tasks
 
 ---
 
-## List Agent Tasks {{ tag: 'GET', label: '/agent/tasks' }}
+## List Agent Tasks I Ds {{ tag: 'GET', label: '/ap/v1/agent/tasks' }}
 <Row>
   <Col>
     List all tasks that have been created for the agent.
@@ -68,9 +93,9 @@ curl --request POST http://localhost:8000/agent/tasks
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/agent/tasks">
+    <CodeGroup title="Request" tag="GET" label="/ap/v1/agent/tasks">
 ```bash {{ title: 'cURL' }}
-curl  http://localhost:8000/agent/tasks
+curl  http://localhost:8000/ap/v1/agent/tasks
 
 ```
     </CodeGroup>
@@ -79,7 +104,7 @@ curl  http://localhost:8000/agent/tasks
 
 ---
 
-## Get Agent Task {{ tag: 'GET', label: '/agent/tasks/<task_id>' }}
+## Get Agent Task {{ tag: 'GET', label: '/ap/v1/agent/tasks/<task_id>' }}
 <Row>
   <Col>
     Get details about a specified agent task.
@@ -100,9 +125,9 @@ curl  http://localhost:8000/agent/tasks
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/agent/tasks/<task_id>">
+    <CodeGroup title="Request" tag="GET" label="/ap/v1/agent/tasks/<task_id>">
 ```bash {{ title: 'cURL' }}
-curl  http://localhost:8000/agent/tasks/[task_id]
+curl  http://localhost:8000/ap/v1/agent/tasks/[task_id]
 
 ```
     </CodeGroup>
@@ -111,7 +136,7 @@ curl  http://localhost:8000/agent/tasks/[task_id]
 
 ---
 
-## List Agent Task Steps {{ tag: 'GET', label: '/agent/tasks/<task_id>/steps' }}
+## List Agent Task Steps {{ tag: 'GET', label: '/ap/v1/agent/tasks/<task_id>/steps' }}
 <Row>
   <Col>
     List all steps for the specified task.
@@ -138,9 +163,9 @@ curl  http://localhost:8000/agent/tasks/[task_id]
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/agent/tasks/<task_id>/steps">
+    <CodeGroup title="Request" tag="GET" label="/ap/v1/agent/tasks/<task_id>/steps">
 ```bash {{ title: 'cURL' }}
-curl  http://localhost:8000/agent/tasks/[task_id]/steps
+curl  http://localhost:8000/ap/v1/agent/tasks/[task_id]/steps
 
 ```
     </CodeGroup>
@@ -149,7 +174,7 @@ curl  http://localhost:8000/agent/tasks/[task_id]/steps
 
 ---
 
-## Execute Agent Task Step {{ tag: 'POST', label: '/agent/tasks/<task_id>/steps' }}
+## Execute Agent Task Step {{ tag: 'POST', label: '/ap/v1/agent/tasks/<task_id>/steps' }}
 <Row>
   <Col>
     Execute a step in the specified agent task.
@@ -169,8 +194,8 @@ curl  http://localhost:8000/agent/tasks/[task_id]/steps
     <Property name="input" type="string" required="undefined">
         Input prompt for the step.
     </Property>
-    <Property name="additional_input" type="object" required="undefined">
-        Input parameters for the task step. Any value is allowed.
+    <Property name="config" type="object" required="undefined">
+        Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.
     </Property>
   </Properties>
    
@@ -180,11 +205,11 @@ curl  http://localhost:8000/agent/tasks/[task_id]/steps
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/agent/tasks/<task_id>/steps">
+    <CodeGroup title="Request" tag="POST" label="/ap/v1/agent/tasks/<task_id>/steps">
 ```bash {{ title: 'cURL' }}
-curl --request POST http://localhost:8000/agent/tasks/[task_id]/steps
+curl --request POST http://localhost:8000/ap/v1/agent/tasks/[task_id]/steps
     -F 'input=[input]'
-    -F 'additional_input=[additional_input]'
+    -F 'config=[config]'
 ```
     </CodeGroup>
   </Col>
@@ -192,7 +217,7 @@ curl --request POST http://localhost:8000/agent/tasks/[task_id]/steps
 
 ---
 
-## Get Agent Task Step {{ tag: 'GET', label: '/agent/tasks/<task_id>/steps/<step_id>' }}
+## Get Agent Task Step {{ tag: 'GET', label: '/ap/v1/agent/tasks/<task_id>/steps/<step_id>' }}
 <Row>
   <Col>
     Get details about a specified task step.
@@ -216,9 +241,9 @@ curl --request POST http://localhost:8000/agent/tasks/[task_id]/steps
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/agent/tasks/<task_id>/steps/<step_id>">
+    <CodeGroup title="Request" tag="GET" label="/ap/v1/agent/tasks/<task_id>/steps/<step_id>">
 ```bash {{ title: 'cURL' }}
-curl  http://localhost:8000/agent/tasks/[task_id]/steps/[step_id]
+curl  http://localhost:8000/ap/v1/agent/tasks/[task_id]/steps/[step_id]
 
 ```
     </CodeGroup>
@@ -227,7 +252,7 @@ curl  http://localhost:8000/agent/tasks/[task_id]/steps/[step_id]
 
 ---
 
-## List Agent Task Artifacts {{ tag: 'GET', label: '/agent/tasks/<task_id>/artifacts' }}
+## List Agent Task Artifacts {{ tag: 'GET', label: '/ap/v1/agent/tasks/<task_id>/artifacts' }}
 <Row>
   <Col>
     List all artifacts that have been created for the given task.
@@ -254,9 +279,9 @@ curl  http://localhost:8000/agent/tasks/[task_id]/steps/[step_id]
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/agent/tasks/<task_id>/artifacts">
+    <CodeGroup title="Request" tag="GET" label="/ap/v1/agent/tasks/<task_id>/artifacts">
 ```bash {{ title: 'cURL' }}
-curl  http://localhost:8000/agent/tasks/[task_id]/artifacts
+curl  http://localhost:8000/ap/v1/agent/tasks/[task_id]/artifacts
 
 ```
     </CodeGroup>
@@ -265,7 +290,7 @@ curl  http://localhost:8000/agent/tasks/[task_id]/artifacts
 
 ---
 
-## Upload Agent Task Artifacts {{ tag: 'POST', label: '/agent/tasks/<task_id>/artifacts' }}
+## Upload Agent Task Artifacts {{ tag: 'POST', label: '/ap/v1/agent/tasks/<task_id>/artifacts' }}
 <Row>
   <Col>
     Upload an artifact for the specified task.
@@ -296,9 +321,9 @@ curl  http://localhost:8000/agent/tasks/[task_id]/artifacts
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="POST" label="/agent/tasks/<task_id>/artifacts">
+    <CodeGroup title="Request" tag="POST" label="/ap/v1/agent/tasks/<task_id>/artifacts">
 ```bash {{ title: 'cURL' }}
-curl --request POST http://localhost:8000/agent/tasks/[task_id]/artifacts
+curl --request POST http://localhost:8000/ap/v1/agent/tasks/[task_id]/artifacts
     -F '@file=[file-path]'
     -F 'relative_path=[relative_path]'
 ```
@@ -308,7 +333,7 @@ curl --request POST http://localhost:8000/agent/tasks/[task_id]/artifacts
 
 ---
 
-## Download Agent Task Artifact {{ tag: 'GET', label: '/agent/tasks/<task_id>/artifacts/<artifact_id>' }}
+## Download Agent Task Artifact {{ tag: 'GET', label: '/ap/v1/agent/tasks/<task_id>/artifacts/<artifact_id>' }}
 <Row>
   <Col>
     Download a specified artifact.
@@ -332,9 +357,9 @@ curl --request POST http://localhost:8000/agent/tasks/[task_id]/artifacts
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Request" tag="GET" label="/agent/tasks/<task_id>/artifacts/<artifact_id>">
+    <CodeGroup title="Request" tag="GET" label="/ap/v1/agent/tasks/<task_id>/artifacts/<artifact_id>">
 ```bash {{ title: 'cURL' }}
-curl  http://localhost:8000/agent/tasks/[task_id]/artifacts/[artifact_id]
+curl  http://localhost:8000/ap/v1/agent/tasks/[task_id]/artifacts/[artifact_id]
 
 ```
     </CodeGroup>

--- a/docs/src/app/page.mdx
+++ b/docs/src/app/page.mdx
@@ -48,8 +48,8 @@ The Agent Protocol is an API specification - list of endpoints, which the agent 
 
 There are two main endpoints:
 
-- `POST /agent/tasks` - for creating tasks
-- `POST /agent/tasks/{id}/steps` - for triggering next step for the task
+- `POST /ap/v1/agent/tasks` - for creating tasks
+- `POST /ap/v1/agent/tasks/{id}/steps` - for triggering next step for the task
 
 To find more details [click here](/protocol).
 

--- a/docs/src/app/protocol/page.mdx
+++ b/docs/src/app/protocol/page.mdx
@@ -71,7 +71,7 @@ An `Artifact` is a file that the agent has worked with. The `Artifact` object ha
 
 The Agent Protocol has two main endpoints:
 
-- `/agent/tasks` **[POST]** - This endpoint is used to create a new task for the agent.
-- `/agent/tasks/{task_id}/steps` **[POST]** - This endpoint is used to trigger next step of the task.
+- `/ap/v1/agent/tasks` **[POST]** - This endpoint is used to create a new task for the agent.
+- `/ap/v1/agent/tasks/{task_id}/steps` **[POST]** - This endpoint is used to trigger next step of the task.
 
 To see all endpoints and their descriptions, please refer to the [Endpoints](/endpoints).

--- a/rfcs/2023-09-15-endpoint-schema-RFC.md
+++ b/rfcs/2023-09-15-endpoint-schema-RFC.md
@@ -1,0 +1,58 @@
+# Standardized Endpoint Schema
+
+| Feature name  | Example name                                |
+| :------------ | :------------------------------------------ |
+| **Author(s)** | J. Zane Cook (jzanecook@z90.studio)                      |
+| **RFC PR:**   | [PR 60](https://github.com/AI-Engineers-Foundation/agent-protocol/pull/60)                                 |
+| **Updated**   | 2023-09-15                                  |
+
+## Summary
+
+This RFC proposes several changes to the Agent Protocol API to improve task, step, and artifact management. Key changes include:
+
+- Prefixing endpoint schema with `/ap/v1/`
+- Removal of `additional_input` from tasks and steps
+- Introduction of the `/ap/v1/agent/info` endpoint
+- Addition of the config field to tasks and steps
+
+## Motivation
+
+The motivation for the changes is to simplify the protocol for users while making it more extensible and feature-rich. Each change aims to refine the protocol to better suit practical needs.
+
+## Agent Builders Benefit
+
+- The new endpoint schema clarifies versioning.
+- The removal of additional_input leads to a leaner API.
+- The new /ap/v1/agent/info endpoint aids in better config management.
+- The config field offers more flexibility for tasks and steps.
+
+## Design Proposal
+
+#### Endpoint Schema Update
+Change the current `/agent/` endpoint schema to `/ap/v1/agent/`. This brings clarity in versioning and separates the agent-specific endpoints under a versioned umbrella. Additionally, the `ap` solidifies the `agent-protocol` URL for clear identification of its usage.
+
+#### Removal of `additional_input`
+Remove the `additional_input` field from both tasks and steps. It complicates the API and most use-cases can be fulfilled without it. If additional data are required, they can be included in the config field.
+
+#### New `/ap/v1/agent/info` Endpoint
+Introduce a new endpoint `/ap/v1/agent/info` that returns metadata about the agent, including a config_options object. This object will specify configurable options available for tasks and steps.
+
+#### Addition of `config` field
+Add a config field to both tasks and steps. This field will allow the user to specify additional parameters or configurations necessary for completing the task or step.
+
+### Alternatives Considered
+
+- Considered keeping `additional_input` but found it redundant when config is introduced. It is also confusing to know what the difference between the input and `additional_input` is for a newcomer, or how it would be used in a standardized way across multiple agents..
+- Considered different naming conventions, but `/ap/v1/` is both intuitive and consistent with standard RESTful practices.
+- Considered not enforcing the full path, but enforcing the full path not only looks better but also creates a better standard for future improvements.
+
+### Compatibility
+These changes are not backwards compatible for the following reasons:
+- The change in the endpoint schema will break existing client implementations tied to the old URL structure.
+- The removal of the `additional_input` field will lead to unexpected behavior for older clients that rely on this field.
+
+Clients will need to update their integrations to accomodate these changes, necessitating a major version bump.
+
+## Questions and Discussion Topics
+
+Are there any edge cases where these changes are insufficient?

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Agent Protocol",
     "description": "Specification of the API protocol for communication with an agent.",
-    "version": "v0.4"
+    "version": "v1"
   },
   "servers": [
     {
@@ -12,7 +12,158 @@
     }
   ],
   "paths": {
-    "/agent/tasks": {
+    "/ap/v1/agent/info": {
+      "get": {
+        "operationId": "getAgentInfo",
+        "summary": "Get information about the agent.",
+        "responses": {
+          "200": {
+            "description": "Returned information about the agent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the agent.",
+                      "type": "string",
+                      "example": "My Agent"
+                    },
+                    "description": {
+                      "description": "Description of the agent.",
+                      "type": "string",
+                      "example": "My agent is the best agent."
+                    },
+                    "version": {
+                      "description": "Version of the agent.",
+                      "type": "string",
+                      "example": "1.0.0"
+                    },
+                    "protocol_version": {
+                      "description": "Version of the agent protocol.",
+                      "type": "string",
+                      "example": 1
+                    },
+                    "github": {
+                      "description": "GitHub repository of the agent.",
+                      "type": "string",
+                      "example": "https://github.com/AI-Engineers-Foundation/agent-protocol"
+                    },
+                    "url": {
+                      "description": "URL of the agent.",
+                      "type": "string",
+                      "example": "https://my-agent.com"
+                    },
+                    "docs": {
+                      "description": "Link to the documentation of the agent.",
+                      "type": "string",
+                      "example": "https://my-agent.com/docs"
+                    },
+                    "issues": {
+                      "description": "Link to the issues of the agent.",
+                      "type": "string",
+                      "example": "https://github.com/AI-Engineers-Foundation/agent-protocol/issues"
+                    },
+                    "config_options": {
+                      "description": "List of configuration options for the agent's tasks and steps. The config is a user-defined set of key/value pairs where the values are standard but the keys are not.",
+                      "type": "object",
+                      "example": "{\n\"debug\": {\n\"type\": \"boolean\",\n\"default\": false,\n\"description\": \"Whether to run the agent in debug mode.\"\n},\n\"model\": {\n\"type\": \"string\",\n\"default\": \"gpt-4\",\n\"description\": \"The model in which the agent's tasks should run.\"\n}\n}",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "description": "The type of the value.",
+                            "type": "string",
+                            "enum": [
+                              "string",
+                              "integer",
+                              "float",
+                              "boolean",
+                              "list",
+                              "dict"
+                            ]
+                          },
+                          "default": {
+                            "description": "The default value of the config option.",
+                            "type": "string"
+                          },
+                          "description": {
+                            "description": "A description of the value with type, default value, and description.",
+                            "type": "string"
+                          },
+                          "options": {
+                            "description": "A list of options for the config option.",
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "oneOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "object"
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "default",
+                          "description"
+                        ],
+                        "example": "{\n\"type\": \"string\",\n\"default\": \"gpt-4\",\n\"description\": \"Model for the agent's steps to use.\"\n\"options\": [\"gpt-4\", \"gpt-3.5-turbo\", \"gpt-3.5-turbo-16k\"]\n}",
+                        "description": "A description of the value with type, default value, and description."
+                      }
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "version",
+                    "protocol_version",
+                    "config_options"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "agent"
+        ]
+      }
+    },
+    "/ap/v1/agent/tasks": {
       "post": {
         "operationId": "createAgentTask",
         "summary": "Creates a task for the agent.",
@@ -29,10 +180,10 @@
                     "example": "Write 'Washington' to the file 'output.txt'.",
                     "nullable": true
                   },
-                  "additional_input": {
-                    "description": "Input parameters for the task. Any value is allowed.",
+                  "config": {
+                    "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                     "type": "object",
-                    "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+                    "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                   }
                 }
               }
@@ -56,10 +207,10 @@
                           "example": "Write 'Washington' to the file 'output.txt'.",
                           "nullable": true
                         },
-                        "additional_input": {
-                          "description": "Input parameters for the task. Any value is allowed.",
+                        "config": {
+                          "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                           "type": "object",
-                          "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+                          "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                         }
                       }
                     },
@@ -151,7 +302,7 @@
         ]
       },
       "get": {
-        "operationId": "listAgentTasks",
+        "operationId": "listAgentTasksIDs",
         "summary": "List all tasks that have been created for the agent.",
         "parameters": [
           {
@@ -203,10 +354,10 @@
                                 "example": "Write 'Washington' to the file 'output.txt'.",
                                 "nullable": true
                               },
-                              "additional_input": {
-                                "description": "Input parameters for the task. Any value is allowed.",
+                              "config": {
+                                "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                                 "type": "object",
-                                "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+                                "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                               }
                             }
                           },
@@ -318,7 +469,7 @@
         ]
       }
     },
-    "/agent/tasks/{task_id}": {
+    "/ap/v1/agent/tasks/{task_id}": {
       "get": {
         "operationId": "getAgentTask",
         "summary": "Get details about a specified agent task.",
@@ -357,10 +508,10 @@
                           "example": "Write 'Washington' to the file 'output.txt'.",
                           "nullable": true
                         },
-                        "additional_input": {
-                          "description": "Input parameters for the task. Any value is allowed.",
+                        "config": {
+                          "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                           "type": "object",
-                          "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+                          "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                         }
                       }
                     },
@@ -454,7 +605,7 @@
         ]
       }
     },
-    "/agent/tasks/{task_id}/steps": {
+    "/ap/v1/agent/tasks/{task_id}/steps": {
       "get": {
         "operationId": "listAgentTaskSteps",
         "summary": "List all steps for the specified task.",
@@ -524,10 +675,10 @@
                                 "example": "Write the words you receive to the file 'output.txt'.",
                                 "nullable": true
                               },
-                              "additional_input": {
-                                "description": "Input parameters for the task step. Any value is allowed.",
+                              "config": {
+                                "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                                 "type": "object",
-                                "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
+                                "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                               }
                             }
                           },
@@ -729,10 +880,10 @@
                     "example": "Write the words you receive to the file 'output.txt'.",
                     "nullable": true
                   },
-                  "additional_input": {
-                    "description": "Input parameters for the task step. Any value is allowed.",
+                  "config": {
+                    "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                     "type": "object",
-                    "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
+                    "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                   }
                 }
               }
@@ -756,10 +907,10 @@
                           "example": "Write the words you receive to the file 'output.txt'.",
                           "nullable": true
                         },
-                        "additional_input": {
-                          "description": "Input parameters for the task step. Any value is allowed.",
+                        "config": {
+                          "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                           "type": "object",
-                          "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
+                          "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                         }
                       }
                     },
@@ -908,7 +1059,7 @@
         ]
       }
     },
-    "/agent/tasks/{task_id}/steps/{step_id}": {
+    "/ap/v1/agent/tasks/{task_id}/steps/{step_id}": {
       "get": {
         "operationId": "getAgentTaskStep",
         "summary": "Get details about a specified task step.",
@@ -967,10 +1118,10 @@
                           "example": "Write the words you receive to the file 'output.txt'.",
                           "nullable": true
                         },
-                        "additional_input": {
-                          "description": "Input parameters for the task step. Any value is allowed.",
+                        "config": {
+                          "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                           "type": "object",
-                          "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
+                          "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                         }
                       }
                     },
@@ -1101,7 +1252,7 @@
         ]
       }
     },
-    "/agent/tasks/{task_id}/artifacts": {
+    "/ap/v1/agent/tasks/{task_id}/artifacts": {
       "get": {
         "operationId": "listAgentTaskArtifacts",
         "summary": "List all artifacts that have been created for the given task.",
@@ -1376,7 +1527,7 @@
         ]
       }
     },
-    "/agent/tasks/{task_id}/artifacts/{artifact_id}": {
+    "/ap/v1/agent/tasks/{task_id}/artifacts/{artifact_id}": {
       "get": {
         "operationId": "downloadAgentTaskArtifact",
         "summary": "Download a specified artifact.",
@@ -1452,6 +1603,139 @@
   },
   "components": {
     "schemas": {
+      "AgentInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the agent.",
+            "type": "string",
+            "example": "My Agent"
+          },
+          "description": {
+            "description": "Description of the agent.",
+            "type": "string",
+            "example": "My agent is the best agent."
+          },
+          "version": {
+            "description": "Version of the agent.",
+            "type": "string",
+            "example": "1.0.0"
+          },
+          "protocol_version": {
+            "description": "Version of the agent protocol.",
+            "type": "string",
+            "example": 1
+          },
+          "github": {
+            "description": "GitHub repository of the agent.",
+            "type": "string",
+            "example": "https://github.com/AI-Engineers-Foundation/agent-protocol"
+          },
+          "url": {
+            "description": "URL of the agent.",
+            "type": "string",
+            "example": "https://my-agent.com"
+          },
+          "docs": {
+            "description": "Link to the documentation of the agent.",
+            "type": "string",
+            "example": "https://my-agent.com/docs"
+          },
+          "issues": {
+            "description": "Link to the issues of the agent.",
+            "type": "string",
+            "example": "https://github.com/AI-Engineers-Foundation/agent-protocol/issues"
+          },
+          "config_options": {
+            "description": "List of configuration options for the agent's tasks and steps. The config is a user-defined set of key/value pairs where the values are standard but the keys are not.",
+            "type": "object",
+            "example": "{\n\"debug\": {\n\"type\": \"boolean\",\n\"default\": false,\n\"description\": \"Whether to run the agent in debug mode.\"\n},\n\"model\": {\n\"type\": \"string\",\n\"default\": \"gpt-4\",\n\"description\": \"The model in which the agent's tasks should run.\"\n}\n}",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "description": "The type of the value.",
+                  "type": "string",
+                  "enum": [
+                    "string",
+                    "integer",
+                    "float",
+                    "boolean",
+                    "list",
+                    "dict"
+                  ]
+                },
+                "default": {
+                  "description": "The default value of the config option.",
+                  "type": "string"
+                },
+                "description": {
+                  "description": "A description of the value with type, default value, and description.",
+                  "type": "string"
+                },
+                "options": {
+                  "description": "A list of options for the config option.",
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "object"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "object"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "type",
+                "default",
+                "description"
+              ],
+              "example": "{\n\"type\": \"string\",\n\"default\": \"gpt-4\",\n\"description\": \"Model for the agent's steps to use.\"\n\"options\": [\"gpt-4\", \"gpt-3.5-turbo\", \"gpt-3.5-turbo-16k\"]\n}",
+              "description": "A description of the value with type, default value, and description."
+            }
+          }
+        },
+        "required": [
+          "name",
+          "version",
+          "protocol_version",
+          "config_options"
+        ]
+      },
       "Pagination": {
         "type": "object",
         "properties": {
@@ -1500,10 +1784,10 @@
                       "example": "Write 'Washington' to the file 'output.txt'.",
                       "nullable": true
                     },
-                    "additional_input": {
-                      "description": "Input parameters for the task. Any value is allowed.",
+                    "config": {
+                      "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                       "type": "object",
-                      "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+                      "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                     }
                   }
                 },
@@ -1620,10 +1904,10 @@
                       "example": "Write the words you receive to the file 'output.txt'.",
                       "nullable": true
                     },
-                    "additional_input": {
-                      "description": "Input parameters for the task step. Any value is allowed.",
+                    "config": {
+                      "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                       "type": "object",
-                      "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
+                      "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
                     }
                   }
                 },
@@ -1835,10 +2119,10 @@
           "pagination"
         ]
       },
-      "TaskInput": {
-        "description": "Input parameters for the task. Any value is allowed.",
+      "TaskOrStepConfiguration": {
+        "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
         "type": "object",
-        "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+        "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
       },
       "Artifact": {
         "description": "An Artifact either created by or submitted to the agent.",
@@ -1892,11 +2176,6 @@
           "file"
         ]
       },
-      "StepInput": {
-        "description": "Input parameters for the task step. Any value is allowed.",
-        "type": "object",
-        "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
-      },
       "StepOutput": {
         "description": "Output that the task step has produced. Any value is allowed.",
         "type": "object",
@@ -1913,10 +2192,10 @@
             "example": "Write 'Washington' to the file 'output.txt'.",
             "nullable": true
           },
-          "additional_input": {
-            "description": "Input parameters for the task. Any value is allowed.",
+          "config": {
+            "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
             "type": "object",
-            "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+            "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
           }
         }
       },
@@ -1932,10 +2211,10 @@
                 "example": "Write 'Washington' to the file 'output.txt'.",
                 "nullable": true
               },
-              "additional_input": {
-                "description": "Input parameters for the task. Any value is allowed.",
+              "config": {
+                "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                 "type": "object",
-                "example": "{\n\"debug\": false,\n\"mode\": \"benchmarks\"\n}"
+                "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
               }
             }
           },
@@ -2007,10 +2286,10 @@
             "example": "Write the words you receive to the file 'output.txt'.",
             "nullable": true
           },
-          "additional_input": {
-            "description": "Input parameters for the task step. Any value is allowed.",
+          "config": {
+            "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
             "type": "object",
-            "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
+            "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
           }
         }
       },
@@ -2026,10 +2305,10 @@
                 "example": "Write the words you receive to the file 'output.txt'.",
                 "nullable": true
               },
-              "additional_input": {
-                "description": "Input parameters for the task step. Any value is allowed.",
+              "config": {
+                "description": "Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.",
                 "type": "object",
-                "example": "{\n\"file_to_refactor\": \"models.py\"\n}"
+                "example": "{\n\"debug\": false,\n\"model\": \"gpt-3.5-turbo-16k\"\n}"
               }
             }
           },

--- a/schemas/openapi.yml
+++ b/schemas/openapi.yml
@@ -2,12 +2,25 @@ openapi: 3.0.1
 info:
   title: Agent Protocol
   description: Specification of the API protocol for communication with an agent.
-  version: v0.4
+  version: v1
 servers:
-  - url: 'http://0.0.0.0:8000'
+  - url: "http://0.0.0.0:8000"
     description: Test server
 paths:
-  /agent/tasks:
+  /ap/v1/agent/info:
+    get:
+      operationId: getAgentInfo
+      summary: Get information about the agent.
+      responses:
+        "200":
+          description: Returned information about the agent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentInfo"
+      tags:
+        - agent
+  /ap/v1/agent/tasks:
     post:
       operationId: createAgentTask
       summary: Creates a task for the agent.
@@ -15,26 +28,26 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TaskRequestBody'
+              $ref: "#/components/schemas/TaskRequestBody"
       responses:
-        '200':
+        "200":
           description: A new agent task was successfully created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Task'
+                $ref: "#/components/schemas/Task"
           x-postman-variables:
             - type: save
               name: task_id
               path: .task_id
-        '422':
-          $ref: '#/components/responses/UnprocessableEntity'
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
         default:
           description: Internal Server Error
       tags:
         - agent
     get:
-      operationId: listAgentTasks
+      operationId: listAgentTasksIDs
       summary: List all tasks that have been created for the agent.
       parameters:
         - name: current_page
@@ -58,17 +71,17 @@ paths:
             minimum: 1
           example: 25
       responses:
-        '200':
+        "200":
           description: Returned list of agent's tasks.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaskListResponse'
+                $ref: "#/components/schemas/TaskListResponse"
         default:
           description: Internal Server Error
       tags:
         - agent
-  '/agent/tasks/{task_id}':
+  "/ap/v1/agent/tasks/{task_id}":
     get:
       operationId: getAgentTask
       summary: Get details about a specified agent task.
@@ -84,19 +97,19 @@ paths:
             - type: load
               name: task_id
       responses:
-        '200':
+        "200":
           description: Returned details about an agent task.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Task'
-        '404':
-          $ref: '#/components/responses/NotFound'
+                $ref: "#/components/schemas/Task"
+        "404":
+          $ref: "#/components/responses/NotFound"
         default:
           description: Internal Server Error
       tags:
         - agent
-  '/agent/tasks/{task_id}/steps':
+  "/ap/v1/agent/tasks/{task_id}/steps":
     get:
       operationId: listAgentTaskSteps
       summary: List all steps for the specified task.
@@ -132,14 +145,14 @@ paths:
             minimum: 1
           example: 25
       responses:
-        '200':
+        "200":
           description: Returned list of agent's steps for the specified task.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaskStepsListResponse'
-        '404':
-          $ref: '#/components/responses/NotFound'
+                $ref: "#/components/schemas/TaskStepsListResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
         default:
           description: Internal Server Error
       tags:
@@ -162,27 +175,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/StepRequestBody'
+              $ref: "#/components/schemas/StepRequestBody"
       responses:
-        '200':
+        "200":
           description: Executed step for the agent task.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Step'
+                $ref: "#/components/schemas/Step"
           x-postman-variables:
             - type: save
               name: step_id
               path: .step_id
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '422':
-          $ref: '#/components/responses/UnprocessableEntity'
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
         default:
           description: Internal Server Error
       tags:
         - agent
-  '/agent/tasks/{task_id}/steps/{step_id}':
+  "/ap/v1/agent/tasks/{task_id}/steps/{step_id}":
     get:
       operationId: getAgentTaskStep
       summary: Get details about a specified task step.
@@ -210,19 +223,19 @@ paths:
             - type: load
               name: step_id
       responses:
-        '200':
+        "200":
           description: Returned details about an agent task step.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Step'
-        '404':
-          $ref: '#/components/responses/NotFound'
+                $ref: "#/components/schemas/Step"
+        "404":
+          $ref: "#/components/responses/NotFound"
         default:
           description: Internal Server Error
       tags:
         - agent
-  '/agent/tasks/{task_id}/artifacts':
+  "/ap/v1/agent/tasks/{task_id}/artifacts":
     get:
       operationId: listAgentTaskArtifacts
       summary: List all artifacts that have been created for the given task.
@@ -258,14 +271,14 @@ paths:
             minimum: 1
           example: 25
       responses:
-        '200':
+        "200":
           description: Returned the list of artifacts for the task.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaskArtifactsListResponse'
-        '404':
-          $ref: '#/components/responses/NotFound'
+                $ref: "#/components/schemas/TaskArtifactsListResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
         default:
           description: Internal Server Error
       tags:
@@ -288,21 +301,21 @@ paths:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ArtifactUpload'
+              $ref: "#/components/schemas/ArtifactUpload"
       responses:
-        '200':
+        "200":
           description: Returned the content of the artifact.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Artifact'
-        '404':
-          $ref: '#/components/responses/NotFound'
+                $ref: "#/components/schemas/Artifact"
+        "404":
+          $ref: "#/components/responses/NotFound"
         default:
           description: Internal Server Error
       tags:
         - agent
-  '/agent/tasks/{task_id}/artifacts/{artifact_id}':
+  "/ap/v1/agent/tasks/{task_id}/artifacts/{artifact_id}":
     get:
       operationId: downloadAgentTaskArtifact
       summary: Download a specified artifact.
@@ -325,21 +338,127 @@ paths:
             type: string
           example: 1e41533e-3904-4401-8a07-c49adf8893de
       responses:
-        '200':
+        "200":
           description: Returned the content of the artifact.
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-        '404':
-          $ref: '#/components/responses/NotFound'
+        "404":
+          $ref: "#/components/responses/NotFound"
         default:
           description: Internal Server Error
       tags:
         - agent
 components:
   schemas:
+    AgentInfo:
+      type: object
+      properties:
+        name:
+          description: Name of the agent.
+          type: string
+          example: My Agent
+        description:
+          description: Description of the agent.
+          type: string
+          example: My agent is the best agent.
+        version:
+          description: Version of the agent.
+          type: string
+          example: 1.0.0
+        protocol_version:
+          description: Version of the agent protocol.
+          type: string
+          example: 1
+        github:
+          description: GitHub repository of the agent.
+          type: string
+          example: https://github.com/AI-Engineers-Foundation/agent-protocol
+        url:
+          description: URL of the agent.
+          type: string
+          example: https://my-agent.com
+        docs:
+          description: Link to the documentation of the agent.
+          type: string
+          example: https://my-agent.com/docs
+        issues:
+          description: Link to the issues of the agent.
+          type: string
+          example: https://github.com/AI-Engineers-Foundation/agent-protocol/issues
+        config_options:
+          description: List of configuration options for the agent's tasks and steps. The config is a user-defined set of key/value pairs where the values are standard but the keys are not.
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              type:
+                description: The type of the value.
+                type: string
+                enum:
+                  - string
+                  - integer
+                  - float
+                  - boolean
+                  - list
+                  - dict
+              default:
+                description: The default value of the config option.
+                type: string
+              description:
+                description: A description of the value with type, default value, and description.
+                type: string
+              options:
+                description: A list of options for the config option.
+                type: array
+                items:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                    - type: number
+                    - type: boolean
+                    - type: object
+                    - type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                          - type: number
+                          - type: boolean
+                          - type: object
+            required:
+              - type
+              - default
+              - description
+            example: |-
+              {
+              "type": "string",
+              "default": "gpt-4",
+              "description": "Model for the agent's steps to use."
+              "options": ["gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-16k"]
+              }
+            description: A description of the value with type, default value, and description.
+
+          example: |-
+            {
+            "debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to run the agent in debug mode."
+            },
+            "model": {
+            "type": "string",
+            "default": "gpt-4",
+            "description": "The model in which the agent's tasks should run."
+            }
+            }
+      required:
+        - name
+        - version
+        - protocol_version
+        - config_options
     Pagination:
       type: object
       properties:
@@ -370,9 +489,9 @@ components:
         tasks:
           type: array
           items:
-            $ref: '#/components/schemas/Task'
+            $ref: "#/components/schemas/Task"
         pagination:
-          $ref: '#/components/schemas/Pagination'
+          $ref: "#/components/schemas/Pagination"
       required:
         - tasks
         - pagination
@@ -382,9 +501,9 @@ components:
         steps:
           type: array
           items:
-            $ref: '#/components/schemas/Step'
+            $ref: "#/components/schemas/Step"
         pagination:
-          $ref: '#/components/schemas/Pagination'
+          $ref: "#/components/schemas/Pagination"
       required:
         - steps
         - pagination
@@ -394,19 +513,19 @@ components:
         artifacts:
           type: array
           items:
-            $ref: '#/components/schemas/Artifact'
+            $ref: "#/components/schemas/Artifact"
         pagination:
-          $ref: '#/components/schemas/Pagination'
+          $ref: "#/components/schemas/Pagination"
       required:
         - artifacts
         - pagination
-    TaskInput:
-      description: Input parameters for the task. Any value is allowed.
+    TaskOrStepConfiguration:
+      description: Config parameters for a task or step. Options must match those specified in the agent's config_options from the info endpoint.
       type: object
       example: |-
         {
         "debug": false,
-        "mode": "benchmarks"
+        "model": "gpt-3.5-turbo-16k"
         }
     Artifact:
       description: An Artifact either created by or submitted to the agent.
@@ -448,13 +567,6 @@ components:
           example: python/code
       required:
         - file
-    StepInput:
-      description: Input parameters for the task step. Any value is allowed.
-      type: object
-      example: |-
-        {
-        "file_to_refactor": "models.py"
-        }
     StepOutput:
       description: Output that the task step has produced. Any value is allowed.
       type: object
@@ -473,11 +585,11 @@ components:
           type: string
           example: Write 'Washington' to the file 'output.txt'.
           nullable: true
-        additional_input:
-          $ref: '#/components/schemas/TaskInput'
+        config:
+          $ref: "#/components/schemas/TaskOrStepConfiguration"
     Task:
       allOf:
-        - $ref: '#/components/schemas/TaskRequestBody'
+        - $ref: "#/components/schemas/TaskRequestBody"
         - type: object
           description: Definition of an agent task.
           required:
@@ -492,7 +604,7 @@ components:
               description: A list of artifacts that the task has produced.
               type: array
               items:
-                $ref: '#/components/schemas/Artifact'
+                $ref: "#/components/schemas/Artifact"
               example:
                 - 7a49f31c-f9c6-4346-a22c-e32bc5af4d8e
                 - ab7b4091-2560-4692-a4fe-d831ea3ca7d6
@@ -506,11 +618,11 @@ components:
           type: string
           example: Write the words you receive to the file 'output.txt'.
           nullable: true
-        additional_input:
-          $ref: '#/components/schemas/StepInput'
+        config:
+          $ref: "#/components/schemas/TaskOrStepConfiguration"
     Step:
       allOf:
-        - $ref: '#/components/schemas/StepRequestBody'
+        - $ref: "#/components/schemas/StepRequestBody"
         - type: object
           required:
             - step_id
@@ -543,15 +655,15 @@ components:
             output:
               description: Output of the task step.
               type: string
-              example: 'I am going to use the write_to_file command and write Washington to a file called output.txt <write_to_file(''output.txt'', ''Washington'')'
+              example: "I am going to use the write_to_file command and write Washington to a file called output.txt <write_to_file('output.txt', 'Washington')"
               nullable: true
             additional_output:
-              $ref: '#/components/schemas/StepOutput'
+              $ref: "#/components/schemas/StepOutput"
             artifacts:
               description: A list of artifacts that the step has produced.
               type: array
               items:
-                $ref: '#/components/schemas/Artifact'
+                $ref: "#/components/schemas/Artifact"
               default: []
             is_last:
               description: Whether this is the last step in the task.

--- a/schemas/openapi.yml
+++ b/schemas/openapi.yml
@@ -4,7 +4,7 @@ info:
   description: Specification of the API protocol for communication with an agent.
   version: v1
 servers:
-  - url: "http://0.0.0.0:8000"
+  - url: 'http://0.0.0.0:8000'
     description: Test server
 paths:
   /ap/v1/agent/info:
@@ -12,12 +12,12 @@ paths:
       operationId: getAgentInfo
       summary: Get information about the agent.
       responses:
-        "200":
+        '200':
           description: Returned information about the agent.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AgentInfo"
+                $ref: '#/components/schemas/AgentInfo'
       tags:
         - agent
   /ap/v1/agent/tasks:
@@ -28,20 +28,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TaskRequestBody"
+              $ref: '#/components/schemas/TaskRequestBody'
       responses:
-        "200":
+        '200':
           description: A new agent task was successfully created.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Task"
+                $ref: '#/components/schemas/Task'
           x-postman-variables:
             - type: save
               name: task_id
               path: .task_id
-        "422":
-          $ref: "#/components/responses/UnprocessableEntity"
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
         default:
           description: Internal Server Error
       tags:
@@ -71,17 +71,17 @@ paths:
             minimum: 1
           example: 25
       responses:
-        "200":
+        '200':
           description: Returned list of agent's tasks.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TaskListResponse"
+                $ref: '#/components/schemas/TaskListResponse'
         default:
           description: Internal Server Error
       tags:
         - agent
-  "/ap/v1/agent/tasks/{task_id}":
+  '/ap/v1/agent/tasks/{task_id}':
     get:
       operationId: getAgentTask
       summary: Get details about a specified agent task.
@@ -97,19 +97,19 @@ paths:
             - type: load
               name: task_id
       responses:
-        "200":
+        '200':
           description: Returned details about an agent task.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Task"
-        "404":
-          $ref: "#/components/responses/NotFound"
+                $ref: '#/components/schemas/Task'
+        '404':
+          $ref: '#/components/responses/NotFound'
         default:
           description: Internal Server Error
       tags:
         - agent
-  "/ap/v1/agent/tasks/{task_id}/steps":
+  '/ap/v1/agent/tasks/{task_id}/steps':
     get:
       operationId: listAgentTaskSteps
       summary: List all steps for the specified task.
@@ -145,14 +145,14 @@ paths:
             minimum: 1
           example: 25
       responses:
-        "200":
+        '200':
           description: Returned list of agent's steps for the specified task.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TaskStepsListResponse"
-        "404":
-          $ref: "#/components/responses/NotFound"
+                $ref: '#/components/schemas/TaskStepsListResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
         default:
           description: Internal Server Error
       tags:
@@ -175,27 +175,27 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/StepRequestBody"
+              $ref: '#/components/schemas/StepRequestBody'
       responses:
-        "200":
+        '200':
           description: Executed step for the agent task.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Step"
+                $ref: '#/components/schemas/Step'
           x-postman-variables:
             - type: save
               name: step_id
               path: .step_id
-        "404":
-          $ref: "#/components/responses/NotFound"
-        "422":
-          $ref: "#/components/responses/UnprocessableEntity"
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
         default:
           description: Internal Server Error
       tags:
         - agent
-  "/ap/v1/agent/tasks/{task_id}/steps/{step_id}":
+  '/ap/v1/agent/tasks/{task_id}/steps/{step_id}':
     get:
       operationId: getAgentTaskStep
       summary: Get details about a specified task step.
@@ -223,19 +223,19 @@ paths:
             - type: load
               name: step_id
       responses:
-        "200":
+        '200':
           description: Returned details about an agent task step.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Step"
-        "404":
-          $ref: "#/components/responses/NotFound"
+                $ref: '#/components/schemas/Step'
+        '404':
+          $ref: '#/components/responses/NotFound'
         default:
           description: Internal Server Error
       tags:
         - agent
-  "/ap/v1/agent/tasks/{task_id}/artifacts":
+  '/ap/v1/agent/tasks/{task_id}/artifacts':
     get:
       operationId: listAgentTaskArtifacts
       summary: List all artifacts that have been created for the given task.
@@ -271,14 +271,14 @@ paths:
             minimum: 1
           example: 25
       responses:
-        "200":
+        '200':
           description: Returned the list of artifacts for the task.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TaskArtifactsListResponse"
-        "404":
-          $ref: "#/components/responses/NotFound"
+                $ref: '#/components/schemas/TaskArtifactsListResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
         default:
           description: Internal Server Error
       tags:
@@ -301,21 +301,21 @@ paths:
         content:
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ArtifactUpload"
+              $ref: '#/components/schemas/ArtifactUpload'
       responses:
-        "200":
+        '200':
           description: Returned the content of the artifact.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Artifact"
-        "404":
-          $ref: "#/components/responses/NotFound"
+                $ref: '#/components/schemas/Artifact'
+        '404':
+          $ref: '#/components/responses/NotFound'
         default:
           description: Internal Server Error
       tags:
         - agent
-  "/ap/v1/agent/tasks/{task_id}/artifacts/{artifact_id}":
+  '/ap/v1/agent/tasks/{task_id}/artifacts/{artifact_id}':
     get:
       operationId: downloadAgentTaskArtifact
       summary: Download a specified artifact.
@@ -338,15 +338,15 @@ paths:
             type: string
           example: 1e41533e-3904-4401-8a07-c49adf8893de
       responses:
-        "200":
+        '200':
           description: Returned the content of the artifact.
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-        "404":
-          $ref: "#/components/responses/NotFound"
+        '404':
+          $ref: '#/components/responses/NotFound'
         default:
           description: Internal Server Error
       tags:
@@ -375,22 +375,35 @@ components:
         github:
           description: GitHub repository of the agent.
           type: string
-          example: https://github.com/AI-Engineers-Foundation/agent-protocol
+          example: 'https://github.com/AI-Engineers-Foundation/agent-protocol'
         url:
           description: URL of the agent.
           type: string
-          example: https://my-agent.com
+          example: 'https://my-agent.com'
         docs:
           description: Link to the documentation of the agent.
           type: string
-          example: https://my-agent.com/docs
+          example: 'https://my-agent.com/docs'
         issues:
           description: Link to the issues of the agent.
           type: string
-          example: https://github.com/AI-Engineers-Foundation/agent-protocol/issues
+          example: 'https://github.com/AI-Engineers-Foundation/agent-protocol/issues'
         config_options:
           description: List of configuration options for the agent's tasks and steps. The config is a user-defined set of key/value pairs where the values are standard but the keys are not.
           type: object
+          example: |-
+            {
+            "debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to run the agent in debug mode."
+            },
+            "model": {
+            "type": "string",
+            "default": "gpt-4",
+            "description": "The model in which the agent's tasks should run."
+            }
+            }
           additionalProperties:
             type: object
             properties:
@@ -408,7 +421,7 @@ components:
                 description: The default value of the config option.
                 type: string
               description:
-                description: A description of the value with type, default value, and description.
+                description: 'A description of the value with type, default value, and description.'
                 type: string
               options:
                 description: A list of options for the config option.
@@ -439,21 +452,7 @@ components:
               "description": "Model for the agent's steps to use."
               "options": ["gpt-4", "gpt-3.5-turbo", "gpt-3.5-turbo-16k"]
               }
-            description: A description of the value with type, default value, and description.
-
-          example: |-
-            {
-            "debug": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether to run the agent in debug mode."
-            },
-            "model": {
-            "type": "string",
-            "default": "gpt-4",
-            "description": "The model in which the agent's tasks should run."
-            }
-            }
+            description: 'A description of the value with type, default value, and description.'
       required:
         - name
         - version
@@ -489,9 +488,9 @@ components:
         tasks:
           type: array
           items:
-            $ref: "#/components/schemas/Task"
+            $ref: '#/components/schemas/Task'
         pagination:
-          $ref: "#/components/schemas/Pagination"
+          $ref: '#/components/schemas/Pagination'
       required:
         - tasks
         - pagination
@@ -501,9 +500,9 @@ components:
         steps:
           type: array
           items:
-            $ref: "#/components/schemas/Step"
+            $ref: '#/components/schemas/Step'
         pagination:
-          $ref: "#/components/schemas/Pagination"
+          $ref: '#/components/schemas/Pagination'
       required:
         - steps
         - pagination
@@ -513,9 +512,9 @@ components:
         artifacts:
           type: array
           items:
-            $ref: "#/components/schemas/Artifact"
+            $ref: '#/components/schemas/Artifact'
         pagination:
-          $ref: "#/components/schemas/Pagination"
+          $ref: '#/components/schemas/Pagination'
       required:
         - artifacts
         - pagination
@@ -586,10 +585,10 @@ components:
           example: Write 'Washington' to the file 'output.txt'.
           nullable: true
         config:
-          $ref: "#/components/schemas/TaskOrStepConfiguration"
+          $ref: '#/components/schemas/TaskOrStepConfiguration'
     Task:
       allOf:
-        - $ref: "#/components/schemas/TaskRequestBody"
+        - $ref: '#/components/schemas/TaskRequestBody'
         - type: object
           description: Definition of an agent task.
           required:
@@ -604,7 +603,7 @@ components:
               description: A list of artifacts that the task has produced.
               type: array
               items:
-                $ref: "#/components/schemas/Artifact"
+                $ref: '#/components/schemas/Artifact'
               example:
                 - 7a49f31c-f9c6-4346-a22c-e32bc5af4d8e
                 - ab7b4091-2560-4692-a4fe-d831ea3ca7d6
@@ -619,10 +618,10 @@ components:
           example: Write the words you receive to the file 'output.txt'.
           nullable: true
         config:
-          $ref: "#/components/schemas/TaskOrStepConfiguration"
+          $ref: '#/components/schemas/TaskOrStepConfiguration'
     Step:
       allOf:
-        - $ref: "#/components/schemas/StepRequestBody"
+        - $ref: '#/components/schemas/StepRequestBody'
         - type: object
           required:
             - step_id
@@ -655,15 +654,15 @@ components:
             output:
               description: Output of the task step.
               type: string
-              example: "I am going to use the write_to_file command and write Washington to a file called output.txt <write_to_file('output.txt', 'Washington')"
+              example: 'I am going to use the write_to_file command and write Washington to a file called output.txt <write_to_file(''output.txt'', ''Washington'')'
               nullable: true
             additional_output:
-              $ref: "#/components/schemas/StepOutput"
+              $ref: '#/components/schemas/StepOutput'
             artifacts:
               description: A list of artifacts that the step has produced.
               type: array
               items:
-                $ref: "#/components/schemas/Artifact"
+                $ref: '#/components/schemas/Artifact'
               default: []
             is_last:
               description: Whether this is the last step in the task.

--- a/sdk/js/src/agent.ts
+++ b/sdk/js/src/agent.ts
@@ -83,7 +83,7 @@ export const createAgentTask = async (
   tasks.push([task, stepHandler])
   return task
 }
-app.post('/agent/tasks', (req, res) => {
+app.post('/ap/v1/agent/tasks', (req, res) => {
   void (async () => {
     try {
       const task = await createAgentTask(req.body)
@@ -102,7 +102,7 @@ app.post('/agent/tasks', (req, res) => {
 export const listAgentTaskIDs = async (): Promise<string[]> => {
   return tasks.map(([task, _]) => task.task_id)
 }
-app.get('/agent/tasks', (req, res) => {
+app.get('/ap/v1/agent/tasks', (req, res) => {
   void (async () => {
     try {
       const ids = await listAgentTaskIDs()
@@ -126,7 +126,7 @@ export const getAgentTask = async (taskId: string): Promise<Task> => {
   }
   return task[0]
 }
-app.get('/agent/tasks/:task_id', (req, res) => {
+app.get('/ap/v1/agent/tasks/:task_id', (req, res) => {
   void (async () => {
     try {
       const task = await getAgentTask(req.params.task_id)
@@ -152,7 +152,7 @@ export const listAgentTaskSteps = async (taskId: string): Promise<string[]> => {
     .filter((step) => step.task_id === taskId)
     .map((step) => step.step_id)
 }
-app.get('/agent/tasks/:task_id/steps', (req, res) => {
+app.get('/ap/v1/agent/tasks/:task_id/steps', (req, res) => {
   void (async () => {
     try {
       const ids = await listAgentTaskSteps(req.params.task_id)
@@ -198,7 +198,7 @@ export const executeAgentTaskStep = async (
   steps.push(step)
   return step
 }
-app.post('/agent/tasks/:task_id/steps', (req, res) => {
+app.post('/ap/v1/agent/tasks/:task_id/steps', (req, res) => {
   void (async () => {
     try {
       const step = await executeAgentTaskStep(req.params.task_id, req.body)
@@ -230,7 +230,7 @@ export const getAgentTaskStep = async (
   }
   return step
 }
-app.get('/agent/tasks/:task_id/steps/:step_id', (req, res) => {
+app.get('/ap/v1/agent/tasks/:task_id/steps/:step_id', (req, res) => {
   void (async () => {
     try {
       const step = await getAgentTaskStep(

--- a/sdk/python/agent_protocol/agent.py
+++ b/sdk/python/agent_protocol/agent.py
@@ -30,7 +30,7 @@ _step_handler: Optional[StepHandler]
 base_router = APIRouter()
 
 
-@base_router.post("/agent/tasks", response_model=Task, tags=["agent"])
+@base_router.post("/ap/v1/agent/tasks", response_model=Task, tags=["agent"])
 async def create_agent_task(body: TaskRequestBody | None = None) -> Task:
     """
     Creates a task for the agent.
@@ -47,7 +47,7 @@ async def create_agent_task(body: TaskRequestBody | None = None) -> Task:
     return task
 
 
-@base_router.get("/agent/tasks", response_model=List[str], tags=["agent"])
+@base_router.get("/ap/v1/agent/tasks", response_model=List[str], tags=["agent"])
 async def list_agent_tasks_ids() -> List[str]:
     """
     List all tasks that have been created for the agent.
@@ -55,7 +55,7 @@ async def list_agent_tasks_ids() -> List[str]:
     return [task.task_id for task in await Agent.db.list_tasks()]
 
 
-@base_router.get("/agent/tasks/{task_id}", response_model=Task, tags=["agent"])
+@base_router.get("/ap/v1/agent/tasks/{task_id}", response_model=Task, tags=["agent"])
 async def get_agent_task(task_id: str) -> Task:
     """
     Get details about a specified agent task.
@@ -64,7 +64,7 @@ async def get_agent_task(task_id: str) -> Task:
 
 
 @base_router.get(
-    "/agent/tasks/{task_id}/steps",
+    "/ap/v1/agent/tasks/{task_id}/steps",
     response_model=List[str],
     tags=["agent"],
 )
@@ -77,7 +77,7 @@ async def list_agent_task_steps(task_id: str) -> List[str]:
 
 
 @base_router.post(
-    "/agent/tasks/{task_id}/steps",
+    "/ap/v1/agent/tasks/{task_id}/steps",
     response_model=Step,
     tags=["agent"],
 )
@@ -109,7 +109,7 @@ async def execute_agent_task_step(
 
 
 @base_router.get(
-    "/agent/tasks/{task_id}/steps/{step_id}",
+    "/ap/v1/agent/tasks/{task_id}/steps/{step_id}",
     response_model=Step,
     tags=["agent"],
 )
@@ -121,7 +121,7 @@ async def get_agent_task_step(task_id: str, step_id: str) -> Step:
 
 
 @base_router.get(
-    "/agent/tasks/{task_id}/artifacts",
+    "/ap/v1/agent/tasks/{task_id}/artifacts",
     response_model=List[Artifact],
     tags=["agent"],
 )
@@ -134,7 +134,7 @@ async def list_agent_task_artifacts(task_id: str) -> List[Artifact]:
 
 
 @base_router.post(
-    "/agent/tasks/{task_id}/artifacts",
+    "/ap/v1/agent/tasks/{task_id}/artifacts",
     response_model=Artifact,
     tags=["agent"],
 )
@@ -162,7 +162,7 @@ async def upload_agent_task_artifacts(
 
 
 @base_router.get(
-    "/agent/tasks/{task_id}/artifacts/{artifact_id}",
+    "/ap/v1/agent/tasks/{task_id}/artifacts/{artifact_id}",
     tags=["agent"],
 )
 async def download_agent_task_artifacts(task_id: str, artifact_id: str) -> FileResponse:

--- a/sdk/python/agent_protocol/utils/compliance/main.py
+++ b/sdk/python/agent_protocol/utils/compliance/main.py
@@ -10,56 +10,56 @@ class TestCompliance:
         return TaskRequestBody(input="test").dict()
 
     def test_create_agent_task(self, url):
-        response = requests.post(f"{url}/agent/tasks", json=self.task_data)
+        response = requests.post(f"{url}/ap/v1/agent/tasks", json=self.task_data)
         assert response.status_code == 200
         assert Task(**response.json()).task_id
 
     def test_list_agent_tasks_ids(self, url):
-        response = requests.get(f"{url}/agent/tasks")
+        response = requests.get(f"{url}/ap/v1/agent/tasks")
         assert response.status_code == 200
         assert isinstance(response.json(), list)
 
     def test_get_agent_task(self, url):
         # Create task
-        response = requests.post(f"{url}/agent/tasks", json=self.task_data)
+        response = requests.post(f"{url}/ap/v1/agent/tasks", json=self.task_data)
         task_id = response.json()["task_id"]
-        response = requests.get(f"{url}/agent/tasks/{task_id}")
+        response = requests.get(f"{url}/ap/v1/agent/tasks/{task_id}")
         assert response.status_code == 200
         assert Task(**response.json()).task_id == task_id
 
     def test_list_agent_task_steps(self, url):
         # Create task
-        response = requests.post(f"{url}/agent/tasks", json=self.task_data)
+        response = requests.post(f"{url}/ap/v1/agent/tasks", json=self.task_data)
         task_id = response.json()["task_id"]
-        response = requests.get(f"{url}/agent/tasks/{task_id}/steps")
+        response = requests.get(f"{url}/ap/v1/agent/tasks/{task_id}/steps")
         assert response.status_code == 200
         assert isinstance(response.json(), list)
 
     def test_execute_agent_task_step(self, url):
         # Create task
-        response = requests.post(f"{url}/agent/tasks", json=self.task_data)
+        response = requests.post(f"{url}/ap/v1/agent/tasks", json=self.task_data)
         task_id = response.json()["task_id"]
         step_body = StepRequestBody(input="test")
         response = requests.post(
-            f"{url}/agent/tasks/{task_id}/steps", json=step_body.dict()
+            f"{url}/ap/v1/agent/tasks/{task_id}/steps", json=step_body.dict()
         )
         assert response.status_code == 200
 
     def test_list_artifacts(self, url):
-        response = requests.post(f"{url}/agent/tasks", json=self.task_data)
+        response = requests.post(f"{url}/ap/v1/agent/tasks", json=self.task_data)
         task_id = response.json()["task_id"]
-        response = requests.get(f"{url}/agent/tasks/{task_id}/artifacts")
+        response = requests.get(f"{url}/ap/v1/agent/tasks/{task_id}/artifacts")
         assert response.status_code == 200
         assert isinstance(response.json(), list)
 
     def test_get_agent_task_step(self, url):
         # Create task
-        response = requests.post(f"{url}/agent/tasks", json=self.task_data)
+        response = requests.post(f"{url}/ap/v1/agent/tasks", json=self.task_data)
         task_id = response.json()["task_id"]
         # Get steps
-        response = requests.get(f"{url}/agent/tasks/{task_id}/steps")
+        response = requests.get(f"{url}/ap/v1/agent/tasks/{task_id}/steps")
         step_id = response.json()[0]
-        response = requests.get(f"{url}/agent/tasks/{task_id}/steps/{step_id}")
+        response = requests.get(f"{url}/ap/v1/agent/tasks/{task_id}/steps/{step_id}")
         assert response.status_code == 200
         assert Step(**response.json()).step_id == step_id
 

--- a/testing_suite/agent_protocol_v1.json
+++ b/testing_suite/agent_protocol_v1.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "84d6bd70-4a9f-4470-be02-f2f9089ec69b",
-		"name": "Agent Protocol - REST v0.4",
+		"name": "Agent Protocol - REST v1",
 		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
 	},
 	"item": [
@@ -55,6 +55,156 @@
 					"response": []
 				},
 				{
+					"name": "Get the agent info",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "32b75035-2164-4ec1-b61c-a86515847037",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "98c48159-7553-4f9b-a1e7-dd66b961ec11",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"id": "52fdb36d-66c1-41e9-b81a-1084ae813a2d",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "mock-match",
+								"value": "19",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": "{{url}}/ap/v1/agent/info"
+					},
+					"response": [
+						{
+							"id": "98f96c46-c680-4377-a681-27b93d8425cf",
+							"name": "mock response",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									},
+									{
+										"key": "mock-match",
+										"value": "19",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": "{{url}}/ap/v1/agent/info"
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Date",
+									"value": "Thu, 17 Aug 2023 18:03:12 GMT",
+									"enabled": true
+								},
+								{
+									"key": "Content-Type",
+									"name": "Content-Type",
+									"value": "application/json",
+									"description": "",
+									"type": "text"
+								},
+								{
+									"key": "Content-Length",
+									"value": "150",
+									"enabled": true
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive",
+									"enabled": true
+								},
+								{
+									"key": "x-srv-trace",
+									"value": "v=1;t=1c95cd08c248d38f",
+									"enabled": true
+								},
+								{
+									"key": "x-srv-span",
+									"value": "v=1;s=2527ca982b2b7c75",
+									"enabled": true
+								},
+								{
+									"key": "Access-Control-Allow-Origin",
+									"value": "*",
+									"enabled": true
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "120",
+									"enabled": true
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "117",
+									"enabled": true
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1692295416",
+									"enabled": true
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"96-S/5iQ2y1qqIInh5BwoPc+chvDJU\"",
+									"enabled": true
+								},
+								{
+									"key": "Vary",
+									"value": "Accept-Encoding",
+									"enabled": true
+								}
+							],
+							"cookie": [],
+							"responseTime": null,
+							"body": "[\n    {\n        \"name\": \"My Agent\",\n        \"description\": \"My agent is the best agent.\",\n        \"version\": \"1.0.0\",\n        \"protocol_version\": \"1\",\n        \"config_options\": {}\n    }\n]"
+						}
+					]
+				},
+				{
 					"name": "Get all the tasks",
 					"event": [
 						{
@@ -100,7 +250,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks"
+						"url": "{{url}}/ap/v1/agent/tasks"
 					},
 					"response": [
 						{
@@ -129,7 +279,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks"
+								"url": "{{url}}/ap/v1/agent/tasks"
 							},
 							"status": "OK",
 							"code": 200,
@@ -265,7 +415,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks"
+						"url": "{{url}}/ap/v1/agent/tasks"
 					},
 					"response": [
 						{
@@ -293,7 +443,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks"
+								"url": "{{url}}/ap/v1/agent/tasks"
 							},
 							"status": "OK",
 							"code": 200,
@@ -463,7 +613,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks/{{task_id}}/steps"
+						"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/steps"
 					},
 					"response": [
 						{
@@ -492,7 +642,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks/{{task_id}}/steps"
+								"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/steps"
 							},
 							"status": "OK",
 							"code": 200,
@@ -589,7 +739,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks/{{task_id}}/steps"
+								"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/steps"
 							},
 							"status": "OK",
 							"code": 200,
@@ -713,7 +863,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks/{{task_id}}/steps"
+						"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/steps"
 					},
 					"response": [
 						{
@@ -742,7 +892,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks/{{task_id}}/steps"
+								"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/steps"
 							},
 							"status": "OK",
 							"code": 200,
@@ -848,7 +998,7 @@
 								"src": ""
 							}
 						},
-						"url": "{{url}}/agent/tasks/{{task_id}}/artifacts/{{artifactId}}"
+						"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/artifacts/{{artifactId}}"
 					},
 					"response": [
 						{
@@ -872,7 +1022,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks/{{task_id}}/artifacts/{{artifactId}}"
+								"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/artifacts/{{artifactId}}"
 							},
 							"status": "OK",
 							"code": 200,
@@ -1019,7 +1169,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks"
+						"url": "{{url}}/ap/v1/agent/tasks"
 					},
 					"response": []
 				},
@@ -1074,7 +1224,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks/{{task_id}}"
+						"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}"
 					},
 					"response": [
 						{
@@ -1092,7 +1242,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks/{{taskId}}"
+								"url": "{{url}}/ap/v1/agent/tasks/{{taskId}}"
 							},
 							"status": "OK",
 							"code": 200,
@@ -1206,7 +1356,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks"
+						"url": "{{url}}/ap/v1/agent/tasks"
 					},
 					"response": []
 				},
@@ -1246,7 +1396,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks"
+						"url": "{{url}}/ap/v1/agent/tasks"
 					},
 					"response": []
 				},
@@ -1327,7 +1477,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{url}}/agent/tasks?page_size=1&current_page=1",
+							"raw": "{{url}}/ap/v1/agent/tasks?page_size=1&current_page=1",
 							"host": [
 								"{{url}}"
 							],
@@ -1411,7 +1561,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks"
+						"url": "{{url}}/ap/v1/agent/tasks"
 					},
 					"response": []
 				},
@@ -1452,7 +1602,7 @@
 								}
 							]
 						},
-						"url": "{{url}}/agent/tasks/{{task_id}}/artifacts"
+						"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/artifacts"
 					},
 					"response": []
 				},
@@ -1492,7 +1642,7 @@
 								}
 							}
 						},
-						"url": "{{url}}/agent/tasks/{{task_id}}/artifacts/{{artifact_id}}"
+						"url": "{{url}}/ap/v1/agent/tasks/{{task_id}}/artifacts/{{artifact_id}}"
 					},
 					"response": [
 						{
@@ -1516,7 +1666,7 @@
 										}
 									}
 								},
-								"url": "{{url}}/agent/tasks/{{taskId}}/artifacts/{{artifactId}}"
+								"url": "{{url}}/ap/v1/agent/tasks/{{taskId}}/artifacts/{{artifactId}}"
 							},
 							"status": "OK",
 							"code": 200,

--- a/testing_suite/test.sh
+++ b/testing_suite/test.sh
@@ -43,6 +43,10 @@ Running the tests, this might take a while. Please wait...
 
 EOF
 
+newman run https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/testing_suite/agent_protocol_v1.json \
+--env-var "url=$URL"
+
+
 newman run https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/testing_suite/contract_tests.json \
 -e https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/testing_suite/contract_tests_env.json \
 --env-var "env-openapi-json-url=https://raw.githubusercontent.com/e2b-dev/agent-protocol/main/schemas/openapi.json" \


### PR DESCRIPTION
- Added `/ap/v1/` before `/agent/`
- Added `/ap/v1/agent/info` endpoint
- Introduced `config_options` to info endpoint
- Removed `additional_input` from tasks and steps
- Added `config` to tasks and steps, based on the `config_options`
- Removing SDK References in the docs (for now, until they are reworked to be compliant)
- Adding AutoGPT Forge to docs

This PR is pre-splitting the repositories.