### PR TITLE
feat(sdk/js): update artifacts

### DIFF
--- a/sdk/js/src/agent.ts
+++ b/sdk/js/src/agent.ts
@@ -51,7 +51,7 @@ export type StepHandler = (input: StepInput | null) => Promise<StepResult>
  * A function that handles a task.
  * Returns a step handler.
  */
-export type TaskHandler = (input: TaskInput | null) => Promise<StepHandler>
+export type TaskHandler = (taskId: String, input: TaskInput | null) => Promise<StepHandler>
 
 const tasks: Array<[Task, StepHandler]> = []
 const steps: Step[] = []
@@ -79,12 +79,12 @@ export const createAgentTask = async (
   if (taskHandler == null) {
     throw new Error('Task handler not defined')
   }
-  const stepHandler = await taskHandler(body?.input ?? null)
   const task: Task = {
     task_id: uuid(),
     input: body?.input ?? null,
     artifacts: [],
   }
+  const stepHandler = await taskHandler(task.task_id, body?.input ?? null)
   tasks.push([task, stepHandler])
   return task
 }
@@ -253,7 +253,7 @@ app.get('/agent/tasks/:task_id/steps/:step_id', (req, res) => {
 })
 
 /**
- * Get the folder of an artifact associated to a task
+ * Get path of an artifact associated to a task
  * @param taskId Task associated with artifact
  * @param artifact Artifact associated with the path returned
  * @returns Absolute path of the artifact
@@ -294,8 +294,7 @@ app.get('/agent/tasks/:task_id/artifacts', (req, res) => {
       const start = (current_page - 1) * page_size
       const end = start + page_size
       const pagedArtifacts = task.artifacts.slice(start, end)
-      console.log({ artifacts: task.artifacts })
-      console.log({ pagedArtifacts })
+
       res.status(200).send({
         artifacts: pagedArtifacts,
         pagination: {

--- a/sdk/js/src/agent.ts
+++ b/sdk/js/src/agent.ts
@@ -260,11 +260,10 @@ app.get('/agent/tasks/:task_id/steps/:step_id', (req, res) => {
  */
 export const getArtifactPath = (taskId: string, artifact: Artifact): string => {
   return path.join(
-    __dirname,
+    process.cwd(),
     WORKSPACE,
     taskId,
     artifact.relative_path ?? '',
-    artifact.artifact_id,
     artifact.file_name
   )
 }
@@ -356,8 +355,8 @@ app.post('/agent/tasks/:task_id/artifacts', (req, res) => {
           .json({ message: 'Unable to find task with the provided id' })
       }
 
-      //@ts-ignore
-      let file = req.files.find(({ fieldname }) => fieldname == 'file')
+      const files = req.files as Array<Express.Multer.File>
+      let file = files.find(({ fieldname }) => fieldname == 'file')
       const artifact = await createArtifact(task[0], file, relativePath)
       res.status(200).json(artifact)
     } catch (err: Error | any) {

--- a/sdk/js/src/agent.ts
+++ b/sdk/js/src/agent.ts
@@ -15,6 +15,7 @@ import {
   type StepResult,
   type Task,
   type TaskRequestBody,
+  StepStatus,
 } from './models'
 
 import spec from '../../../schemas/openapi.yml'
@@ -191,7 +192,9 @@ export const executeAgentTaskStep = async (
     output: stepResult.output ?? null,
     artifacts: stepResult.artifacts ?? [],
     is_last: stepResult.is_last ?? false,
+    status: StepStatus.COMPLETED
   }
+
   if (step.artifacts != null) {
     if (task[0].artifacts == null || task[0].artifacts.length === 0) {
       task[0].artifacts = step.artifacts
@@ -283,6 +286,7 @@ export const createArtifact = async (
     agent_created: false,
     file_name: file.originalname,
     relative_path: relativePath || null,
+    created_at: Date.now().toString(),
   }
   task.artifacts = task.artifacts || []
   task.artifacts.push(artifact)

--- a/sdk/js/src/models.ts
+++ b/sdk/js/src/models.ts
@@ -11,6 +11,7 @@ export type Artifact = {
   agent_created: boolean,
   file_name: string,
   relative_path: string | null,
+  created_at: string
 }
 
 /**
@@ -22,6 +23,12 @@ export type StepInput = any
  * Output that the task step has produced. Any value is allowed.
  */
 export type StepOutput = any
+
+export enum StepStatus {
+  CREATED = "created",
+  RUNNING = "running",
+  COMPLETED = "completed"
+}
 
 export interface Step {
   output?: StepOutput
@@ -42,6 +49,10 @@ export interface Step {
    * The ID of the task step.
    */
   step_id: string
+  /**
+   * Current status of step
+   */
+  status: StepStatus
 }
 
 export interface StepRequestBody {

--- a/sdk/js/src/models.ts
+++ b/sdk/js/src/models.ts
@@ -6,7 +6,12 @@ export type TaskInput = any
 /**
  * Artifact that the task has produced. Any value is allowed.
  */
-export type Artifact = any
+export type Artifact = {
+  artifact_id: string,
+  agent_created: boolean,
+  file_name: string,
+  relative_path: string | null,
+}
 
 /**
  * Input parameters for the task step. Any value is allowed.


### PR DESCRIPTION
This PR aims to support two endpoints that were missing from the [Agent Protocol Specification](https://github.com/AI-Engineers-Foundation/agent-protocol/blob/main/schemas/openapi.yml) in the JS SDK:

- POST `/agent/tasks/{task_id}/artifacts` -> To upload artifacts for a given task
- GET `/agent/tasks/{task_id}/artifacts/{artifact_id}` -> To download artifacts from a given task
- GET `/agent/tasks/{task_id}/artifacts` -> Get the list of artifacts from a given task

It's worth mentioning that I've noticed that you started the migration of these SDK into their own repositories, but since it's a WIP I decided to open the PR here - If you feel that I should open the PR in the other repository just let me know (I also saw that [it has some broken links](https://github.com/AI-Engineers-Foundation/agent-protocol-sdk-js/blob/main/src/agent.ts#L18)).

I also have some questions regarding how the steps are handled - I noticed that in the Python SDK they're first created and the Status is defined as `created` but in JS we're not doing that; I updated it to be [`completed` once the `handler` has finished](https://github.com/cbrzn/agent-protocol/blob/feat/update-artifacts/sdk/js/src/agent.ts#L187-L195) but tbh I don't think this is handled okay, so I am looking for feedback here

Also, we're able to run a test suite in [our agent](https://github.com/polywrap/evo.ninja/pull/179) with these changes. This is how I tested things :smile: 